### PR TITLE
feat: add bun, opencode, android/java support and clean up config

### DIFF
--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -1,0 +1,187 @@
+# This is terribly complicated
+# It's because:
+# 1. bun run has to have dynamic completions
+# 2. there are global options
+# 3. bun {install add remove} gets special options
+# 4. I don't know how to write fish completions well
+# Contributions very welcome!!
+
+function __fish__get_bun_bins
+	string split ' ' (bun getcompletes b)
+end
+
+function __fish__get_bun_scripts
+	set -lx SHELL bash
+	set -lx MAX_DESCRIPTION_LEN 40
+	string trim (string split '\n' (string split '\t' (bun getcompletes z)))
+end
+
+function __fish__get_bun_packages
+	if test (commandline -ct) != ""
+		set -lx SHELL fish
+		string split ' ' (bun getcompletes a (commandline -ct))
+	end
+end
+
+function __history_completions
+	set -l tokens (commandline --current-process --tokenize)
+	history --prefix (commandline) | string replace -r \^$tokens[1]\\s\* "" | string replace -r \^$tokens[2]\\s\* "" | string split ' '
+end
+
+function __fish__get_bun_bun_js_files
+	string split ' ' (bun getcompletes j)
+end
+
+set -l bun_install_boolean_flags yarn production optional development no-save dry-run force no-cache silent verbose global
+set -l bun_install_boolean_flags_descriptions "Write a yarn.lock file (yarn v1)" "Don't install devDependencies" "Add dependency to optionalDependencies" "Add dependency to devDependencies" "Don't update package.json or save a lockfile" "Don't install anything" "Always request the latest versions from the registry & reinstall all dependencies" "Ignore manifest cache entirely" "Don't output anything" "Excessively verbose logging" "Use global folder"
+
+set -l bun_builtin_cmds_without_run dev create help bun upgrade discord install remove add update init pm x
+set -l bun_builtin_cmds_accepting_flags create help bun upgrade discord run init link unlink pm x update
+
+function __bun_complete_bins_scripts --inherit-variable bun_builtin_cmds_without_run -d "Emit bun completions for bins and scripts"
+    # Do nothing if we already have a builtin subcommand,
+    # or any subcommand other than "run".
+    if __fish_seen_subcommand_from $bun_builtin_cmds_without_run
+    or not __fish_use_subcommand && not __fish_seen_subcommand_from run
+        return
+    end
+    # Do we already have a bin or script subcommand?
+    set -l bins (__fish__get_bun_bins)
+    if __fish_seen_subcommand_from $bins
+        return
+    end
+    # Scripts have descriptions appended with a tab separator.
+    # Strip off descriptions for the purposes of subcommand testing.
+    set -l scripts (__fish__get_bun_scripts)
+    if __fish_seen_subcommand_from (string split \t -f 1 -- $scripts)
+        return
+    end
+    # Emit scripts.
+    for script in $scripts
+        echo $script
+    end
+    # Emit binaries and JS files (but only if we're doing `bun run`).
+    if __fish_seen_subcommand_from run
+        for bin in $bins
+            echo "$bin"\t"package bin"
+        end
+        for file in (__fish__get_bun_bun_js_files)
+            echo "$file"\t"Bun.js"
+        end
+    end
+end
+
+
+# Clear existing completions
+complete -e -c bun
+
+# Dynamically emit scripts and binaries
+complete -c bun -f -a "(__bun_complete_bins_scripts)"
+
+# Complete flags if we have no subcommand or a flag-friendly one.
+set -l flag_applies "__fish_use_subcommand; or __fish_seen_subcommand_from $bun_builtin_cmds_accepting_flags"
+complete -c bun \
+	-n $flag_applies --no-files -s 'u' -l 'origin' -r -d 'Server URL. Rewrites import paths'
+complete -c bun \
+	-n $flag_applies --no-files  -s 'p' -l 'port' -r -d 'Port number to start server from'
+complete -c bun \
+	-n $flag_applies --no-files  -s 'd' -l 'define' -r -d 'Substitute K:V while parsing, e.g. --define process.env.NODE_ENV:\"development\"'
+complete -c bun \
+	-n $flag_applies --no-files  -s 'e' -l 'external' -r -d 'Exclude module from transpilation (can use * wildcards). ex: -e react'
+complete -c bun \
+	-n $flag_applies --no-files -l 'use' -r -d 'Use a framework (ex: next)'
+complete -c bun \
+	-n $flag_applies --no-files -l 'hot' -r -d 'Enable hot reloading in Bun\'s JavaScript runtime'
+
+# Complete dev and create as first subcommand.
+complete -c bun \
+	-n "__fish_use_subcommand" -a 'dev' -d 'Start dev server'
+complete -c bun \
+	-n "__fish_use_subcommand" -a 'create' -f -d 'Create a new project from a template'
+
+# Complete "next" and "react" if we've seen "create".
+complete -c bun \
+	-n "__fish_seen_subcommand_from create" -a 'next' -d 'new Next.js project'
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from create" -a 'react' -d 'new React project'
+
+# Complete "upgrade" as first subcommand.
+complete -c bun \
+	-n "__fish_use_subcommand" -a 'upgrade' -d 'Upgrade bun to the latest version' -x
+# Complete "-h/--help" unconditionally.
+complete -c bun \
+	-s "h" -l "help" -d 'See all commands and flags' -x
+
+# Complete "-v/--version" if we have no subcommand.
+complete -c bun \
+	-n "not __fish_use_subcommand" -l "version" -s "v" -d 'Bun\'s version' -x
+
+# Complete additional subcommands.
+complete -c bun \
+	-n "__fish_use_subcommand" -a 'discord' -d 'Open bun\'s Discord server' -x
+
+
+complete -c bun \
+	-n "__fish_use_subcommand" -a 'bun' -d 'Generate a new bundle'
+
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from bun" -F -d 'Bundle this'
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from create; and __fish_seen_subcommand_from react next" -F -d "Create in directory"
+
+
+complete -c bun \
+	-n "__fish_use_subcommand" -a 'init' -F -d 'Start an empty Bun project'
+
+complete -c bun \
+	-n "__fish_use_subcommand" -a 'install' -f -d 'Install packages from package.json'
+
+complete -c bun \
+	-n "__fish_use_subcommand" -a 'add' -F -d 'Add a package to package.json'
+
+complete -c bun \
+	-n "__fish_use_subcommand" -a 'remove' -F -d 'Remove a package from package.json'
+
+
+for i in (seq (count $bun_install_boolean_flags))
+	complete -c bun \
+		-n "__fish_seen_subcommand_from install add remove update" -l "$bun_install_boolean_flags[$i]" -d "$bun_install_boolean_flags_descriptions[$i]"
+end
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from install add remove update" -l 'cwd' -d 'Change working directory'
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from install add remove update" -l 'cache-dir' -d 'Choose a cache directory (default: $HOME/.bun/install/cache)'
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from add" -d 'Popular' -a '(__fish__get_bun_packages)'
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from add" -d 'History' -a '(__history_completions)'
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from pm; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) cache;" -a 'bin ls cache hash hash-print hash-string' -f
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from pm; and __fish_seen_subcommand_from cache; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts);" -a 'rm' -f
+
+# Add built-in subcommands with descriptions.
+complete -c bun -n "__fish_use_subcommand" -a "create" -f -d "Create a new project from a template"
+complete -c bun -n "__fish_use_subcommand" -a "build bun" --require-parameter -F -d "Transpile and bundle one or more files"
+complete -c bun -n "__fish_use_subcommand" -a "upgrade" -d "Upgrade Bun"
+complete -c bun -n "__fish_use_subcommand" -a "run" -d "Run a script or package binary"
+complete -c bun -n "__fish_use_subcommand" -a "install" -d "Install dependencies from package.json" -f
+complete -c bun -n "__fish_use_subcommand" -a "remove" -d "Remove a dependency from package.json" -f
+complete -c bun -n "__fish_use_subcommand" -a "add" -d "Add a dependency to package.json" -f
+complete -c bun -n "__fish_use_subcommand" -a "init" -d "Initialize a Bun project in this directory" -f
+complete -c bun -n "__fish_use_subcommand" -a "link" -d "Register or link a local npm package" -f
+complete -c bun -n "__fish_use_subcommand" -a "unlink" -d "Unregister a local npm package" -f
+complete -c bun -n "__fish_use_subcommand" -a "pm" -d "Additional package management utilities" -f
+complete -c bun -n "__fish_use_subcommand" -a "x" -d "Execute a package binary, installing if needed" -f
+complete -c bun -n "__fish_use_subcommand" -a "outdated" -d "Display the latest versions of outdated dependencies" -f
+complete -c bun -n "__fish_use_subcommand" -a "update" -d "Update dependencies to their latest versions" -f
+complete -c bun -n "__fish_use_subcommand" -a "publish" -d "Publish your package from local to npm" -f

--- a/conf.d/fish_frozen_key_bindings.fish
+++ b/conf.d/fish_frozen_key_bindings.fish
@@ -1,0 +1,14 @@
+# This file was created by fish when upgrading to version 4.3, to migrate
+# the 'fish_key_bindings' variable from its old default scope (universal)
+# to its new default scope (global).  We recommend you delete this file
+# and configure key bindings in ~/.config/fish/config.fish if needed.
+
+set --global fish_key_bindings fish_vi_key_bindings
+
+# Prior to version 4.3, fish shipped an event handler that runs
+# `set --universal fish_key_bindings fish_default_key_bindings`
+# whenever the fish_key_bindings variable is erased.
+# This means that as long as any fish < 4.3 is still running on this system,
+# we cannot complete the migration.
+# As a workaround, erase the universal variable at every shell startup.
+set --erase --universal fish_key_bindings

--- a/conf.d/fish_frozen_theme.fish
+++ b/conf.d/fish_frozen_theme.fish
@@ -1,0 +1,37 @@
+# This file was created by fish when upgrading to version 4.3, to migrate
+# theme variables from universal to global scope.
+# Don't edit this file, as it will be written by the web-config tool (`fish_config`).
+# To customize your theme, delete this file and see
+#     help interactive#syntax-highlighting
+# or
+#     man fish-interactive | less +/^SYNTAX.HIGHLIGHTING
+# for appropriate commands to add to ~/.config/fish/config.fish instead.
+# See also the release notes for fish 4.3.0 (run `help relnotes`).
+
+set --global fish_color_autosuggestion brblack
+set --global fish_color_cancel -r
+set --global fish_color_command blue
+set --global fish_color_comment red
+set --global fish_color_cwd green
+set --global fish_color_cwd_root red
+set --global fish_color_end green
+set --global fish_color_error brred
+set --global fish_color_escape brcyan
+set --global fish_color_history_current --bold
+set --global fish_color_host normal
+set --global fish_color_host_remote yellow
+set --global fish_color_normal normal
+set --global fish_color_operator brcyan
+set --global fish_color_param cyan
+set --global fish_color_quote yellow
+set --global fish_color_redirection cyan --bold
+set --global fish_color_search_match white --background=brblack
+set --global fish_color_selection white --bold --background=brblack
+set --global fish_color_status red
+set --global fish_color_user brgreen
+set --global fish_color_valid_path --underline
+set --global fish_pager_color_completion normal
+set --global fish_pager_color_description yellow -i
+set --global fish_pager_color_prefix normal --bold --underline
+set --global fish_pager_color_progress brwhite --background=cyan
+set --global fish_pager_color_selected_background -r

--- a/conf.d/myabbrs.fish
+++ b/conf.d/myabbrs.fish
@@ -18,7 +18,7 @@ abbr -a -- gd git diff
 abbr -a -- gds git diff --staged
 abbr -a -- gf git fetch
 abbr -a -- gl git log
-abbr -a -- glop git log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
+# abbr -a -- glop git log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
 abbr -a -- gm git merge
 abbr -a -- gp git pull
 abbr -a -- gpr git pull --rebase
@@ -86,8 +86,7 @@ abbr -a -- drmf docker rm -f
 abbr -a -- dprune docker system prune -af --volumes
 
 # Ruby specific abbreviations
-abbr -a be -- bundle exec
-abbr -a beru -- bundle exec ruby
-abbr -a -- berc bundle exec rails console
 abbr -a -- be bundle exec
+abbr -a -- beru bundle exec ruby
+abbr -a -- berc bundle exec rails console
 abbr -a -- osp "rm -rf ./.overmind.sock && overmind start -f Procfile.dev"

--- a/config.fish
+++ b/config.fish
@@ -14,3 +14,24 @@ if status is-interactive
     direnv hook fish | source
     source $HOME/.local/bin/env.fish
 end
+
+# opencode
+fish_add_path $HOME/.opencode/bin
+
+# bun
+set --export BUN_INSTALL "$HOME/.bun"
+set --export PATH $BUN_INSTALL/bin $PATH
+
+if test (uname) = Darwin
+    set -gx ANDROID_HOME $HOME/Library/Android/sdk
+    set -gx JAVA_HOME (/usr/libexec/java_home -v 21)
+    fish_add_path $ANDROID_HOME/emulator
+    fish_add_path $ANDROID_HOME/platform-tools
+    # imagemagick
+    fish_add_path /opt/homebrew/opt/imagemagick-full/bin
+    set -gx LDFLAGS "-L/opt/homebrew/opt/imagemagick-full/lib"
+    set -gx CPPFLAGS "-I/opt/homebrew/opt/imagemagick-full/include"
+    set -gx PKG_CONFIG_PATH "/opt/homebrew/opt/imagemagick-full/lib/pkgconfig"
+end
+
+alias glop='git log --oneline --pretty=format:"%C(auto)%h %Cgreen%ad %Cblue(%an)%Creset %s" --date=format:"%Y-%m-%d %H:%M"'

--- a/fish_variables
+++ b/fish_variables
@@ -1,39 +1,14 @@
 # This file contains fish universal variable definitions.
 # VERSION: 3.0
+SETUVAR --export ANDROID_HOME:/Users/stonecharioteer/Library/Android/sdk
 SETUVAR --export EDITOR:nvim
+SETUVAR --export JAVA_HOME:/Library/Java/JavaVirtualMachines/zulu\x2d17\x2ejdk/Contents/Home
+SETUVAR PYO3_USE_ABI3_FORWARD_COMPATIBILITY:1
 SETUVAR --export RUBYOPT:\x2drlogger
 SETUVAR --export VISUAL:nvim
-SETUVAR __fish_initialized:3800
+SETUVAR __fish_initialized:4300
 SETUVAR _fisher_jorgebucaran_2F_fisher_files:\x7e/\x2econfig/fish/functions/fisher\x2efish\x1e\x7e/\x2econfig/fish/completions/fisher\x2efish
 SETUVAR _fisher_plugins:jorgebucaran/fisher
 SETUVAR _fisher_upgraded_to_4_4:\x1d
 SETUVAR dev_user_paths:/Users/stonecharioteer/\x2ecargo/bin\x1e/Users/stonecharioteer/\x2efzf/bin
-SETUVAR fish_color_autosuggestion:brblack
-SETUVAR fish_color_cancel:\x2dr
-SETUVAR fish_color_command:blue
-SETUVAR fish_color_comment:red
-SETUVAR fish_color_cwd:green
-SETUVAR fish_color_cwd_root:red
-SETUVAR fish_color_end:green
-SETUVAR fish_color_error:brred
-SETUVAR fish_color_escape:brcyan
-SETUVAR fish_color_history_current:\x2d\x2dbold
-SETUVAR fish_color_host:normal
-SETUVAR fish_color_host_remote:yellow
-SETUVAR fish_color_normal:normal
-SETUVAR fish_color_operator:brcyan
-SETUVAR fish_color_param:cyan
-SETUVAR fish_color_quote:yellow
-SETUVAR fish_color_redirection:cyan\x1e\x2d\x2dbold
-SETUVAR fish_color_search_match:white\x1e\x2d\x2dbackground\x3dbrblack
-SETUVAR fish_color_selection:white\x1e\x2d\x2dbold\x1e\x2d\x2dbackground\x3dbrblack
-SETUVAR fish_color_status:red
-SETUVAR fish_color_user:brgreen
-SETUVAR fish_color_valid_path:\x2d\x2dunderline
-SETUVAR fish_key_bindings:fish_vi_key_bindings
-SETUVAR fish_pager_color_completion:normal
-SETUVAR fish_pager_color_description:yellow\x1e\x2di
-SETUVAR fish_pager_color_prefix:normal\x1e\x2d\x2dbold\x1e\x2d\x2dunderline
-SETUVAR fish_pager_color_progress:brwhite\x1e\x2d\x2dbackground\x3dcyan
-SETUVAR fish_pager_color_selected_background:\x2dr
 SETUVAR fish_user_paths:/Users/stonecharioteer/\x2ecargo/bin\x1e/Users/stonecharioteer/code/checkouts/personal/scripts\x1e/home/stonecharioteer/code/checkouts/personal/scripts\x1e/home/stonecharioteer/\x2ecargo/bin\x1e/home/stonecharioteer/\x2efzf/bin\x1e/Applications/Ghostty\x2eapp/Contents/MacOS\x1e/usr/bin


### PR DESCRIPTION
## Summary
- Add bun completions and PATH setup, opencode PATH, Android SDK/Java and ImageMagick support (macOS-only with platform checks)
- Fix hardcoded paths to use `$HOME`, remove duplicate `be` abbreviation and cargo bin PATH
- Update fisher to 4.4.8, add fish 4.3 migration files (frozen theme/key bindings), move `glop` to alias

## Test plan
- [ ] Verify `source ~/.config/fish/config.fish` loads without errors on macOS
- [ ] Verify abbreviations work: `abbr -l` shows no duplicates
- [ ] Verify `glop` alias works in a git repo
- [ ] Verify bun completions work with `bun <tab>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)